### PR TITLE
Minor fixes to enable plugin code minification

### DIFF
--- a/js/CoGe.profile.js
+++ b/js/CoGe.profile.js
@@ -1,0 +1,73 @@
+function copyOnly(mid) {
+    return mid in {
+        // There are no modules right now that are copy-only. If you have some, though, just add
+        // them here like this:
+        // 'app/module': 1
+    };
+}
+
+var profile = {
+    action: 'release',
+    cssOptimize: 'comments',
+    mini: true,
+
+    basePath: '../../../src',
+    packages: [
+        {name: 'CoGe', location: '../plugins/CoGe/js' }
+    ],
+
+    layerOptimize: 'closure',
+    stripConsole: 'normal',
+    selectorEngine: 'acme',
+
+    layers: {
+        'CoGe/main': {
+            include: [
+                'CoGe',
+                'CoGe/Store/SeqFeature/Search',
+                'CoGe/View/ColorDialog',
+                'CoGe/View/Track/CoGeAlignment',
+                'CoGe/View/Track/CoGeFeatures',
+                'CoGe/View/Track/CoGeVariants',
+                'CoGe/View/Track/GC_Content',
+                'CoGe/View/Track/Markers',
+                'CoGe/View/Track/Wiggle/Density',
+                'CoGe/View/Track/Wiggle/XYPlot',
+                'CoGe/View/Track/Wiggle/_Scale',
+                'CoGe/View/TrackList/CoGe'
+            ],
+            exclude: [ 'JBrowse' ]
+        }
+    },
+
+    staticHasFeatures: {
+        'dojo-trace-api':0,
+        'dojo-log-api':0,
+        'dojo-publish-privates':0,
+        'dojo-sync-loader':0,
+        'dojo-xhr-factory':0,
+        'dojo-test-sniff':0
+    },
+
+    resourceTags: {
+        // Files that contain test code.
+        test: function (filename, mid) {
+            return false;
+        },
+
+        // Files that should be copied as-is without being modified by the build system.
+        copyOnly: function (filename, mid) {
+            return copyOnly(mid);
+        },
+
+        // Files that are AMD modules.
+        amd: function (filename, mid) {
+            return !copyOnly(mid) && /.js$/.test(filename);
+        },
+
+        // Files that should not be copied when the “mini” compiler flag is set to true.
+        miniExclude: function (filename, mid) {
+            return ! ( /^CoGe/.test(mid) );
+        }
+    }
+};

--- a/js/View/ColorDialog.js
+++ b/js/View/ColorDialog.js
@@ -32,7 +32,7 @@ return declare( ActionBarDialog,
 
     _fillActionBar: function( actionBar ) {
         var self = this;
- 
+
         if (this.items.length == 1)
             domConstruct.place(domConstruct.toDom('<div style="margin-bottom:10px;">' + this.items[0].label + '</div>'), actionBar);
         else
@@ -95,6 +95,6 @@ return declare( ActionBarDialog,
     show: function( ) {
         this.inherited( arguments );
         focus.focus( this.closeButtonNode );
-    },
+    }
 });
 });

--- a/js/View/Track/Wiggle/XYPlot.js
+++ b/js/View/Track/Wiggle/XYPlot.js
@@ -176,8 +176,8 @@ var XYPlot = declare( [XYPlotBase], {
 					//pos_color: 'blue',
 					//neg_color: 'red',
 					origin_color: '#888',
-					variance_band_color: 'rgba(0,0,0,0.3)',
-				},
+					variance_band_color: 'rgba(0,0,0,0.3)'
+				}
 			}
 		);
 	},
@@ -445,7 +445,7 @@ var XYPlot = declare( [XYPlotBase], {
 			return name;
 		}
 	},
- 
+
 	// ----------------------------------------------------------------
 
    getGlobalStats: function( successCallback, errorCallback ) {
@@ -775,7 +775,7 @@ var XYPlot = declare( [XYPlotBase], {
 						if (!track._color_dialog) {
 							track._color_dialog = new ColorDialog({
 								title: "Change colors",
-								style: { width: '230px', },
+								style: { width: '230px' },
 								track: track,
 								items: config.coge.experiments || [{value: config.coge.id, label: config.coge.name}],
 								featureColor: dojo.byId(config.track).config.style.featureColor,
@@ -1045,7 +1045,7 @@ function chart(div, first, gap, counts) {
 		axis = d3.svg.axis().orient("bottom").scale(x),
 		width = x.range()[1],
 		height = y.range()[0];
-  
+
 	var g = div.append("svg")
 		.attr("width", width + margin.left + margin.right)
 		.attr("height", height + margin.top + margin.bottom)

--- a/js/View/TrackList/CoGe.js
+++ b/js/View/TrackList/CoGe.js
@@ -693,7 +693,7 @@ define(['dojo/_base/declare',
 
 	// ----------------------------------------------------------------
 
-	_in_notebook(container)
+    _in_notebook: function(container)
 	{
 		return container.parentNode.firstChild.lastChild.innerHTML != 'All Experiments';
 	},
@@ -881,7 +881,7 @@ define(['dojo/_base/declare',
 		var coge = track_config.coge;
 		var container = dojo.create( 'div', {
 			className: 'coge-track',
-			id: track_config.track,
+			id: track_config.track
 		});
 		container.config = track_config;
 		var label = dojo.create('div', {

--- a/js/main.js
+++ b/js/main.js
@@ -431,13 +431,13 @@ return declare( JBrowsePlugin,
 
 	// ----------------------------------------------------------------
 
-	_button(text, onclick) {
+	_button: function(text, onclick) {
 		return '<button data-dojo-type="dijit/form/Button" type="button" onClick="' + onclick + '">' + text + '</button>';
 	},
 
 	// ----------------------------------------------------------------
 
-	build_buttons(ok_onclick, cancel_onclick) {
+	build_buttons: function(ok_onclick, cancel_onclick) {
 		return '<div class="dijitDialogPaneActionBar">' + this._button('OK', ok_onclick) + this._button('Cancel', cancel_onclick) + '</div>';
 	},
 
@@ -1010,7 +1010,7 @@ return declare( JBrowsePlugin,
 			config: config,
 			refSeq: browser.refSeq,
 			type: 'JBrowse/Store/SeqFeature/REST',
-			baseUrl: api_base_url + '/experiment/' + eids.join(','),
+			baseUrl: api_base_url + '/experiment/' + eids.join(',')
 		};
 		this._new_store(store_config, function(store_name) {
 			config = self._clone_config(config);


### PR DESCRIPTION
+ Add plugin profile.js
+ Fix js syntax issues

These changes should now allow the JBrowse build process to successfully minify the CoGe plugin code when running the command:  
`make -f build/Makefile release-notest`

Thank you, @sdavey, for extracting the CoGe plugin code into a separate repo (LyonsLab/coge#75).

Please review these changes and incorporate at your convenience.